### PR TITLE
{#52} - review lecture refactoring

### DIFF
--- a/src/main/java/com/cherrypick/backend/application/ReviewFacade.java
+++ b/src/main/java/com/cherrypick/backend/application/ReviewFacade.java
@@ -7,7 +7,6 @@ import com.cherrypick.backend.presentation.review.ReviewDto.PreviewReviewRespons
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -22,12 +21,8 @@ public class ReviewFacade {
     reviewService.createReview(command);
   }
 
-  public Page<ReviewDetail> inquiryReviews(Long lectureId, Pageable pageable) {
-    return reviewService.inquiryReviews(lectureId, pageable);
-  }
-
-  public Slice<ReviewDetail> inquiryReviewsForMobile(Long lectureId, Pageable pageable) {
-    return reviewService.inquiryReviewsForMobile(lectureId, pageable);
+  public Slice<ReviewDetail> inquiryReviews(Long lectureId, Pageable pageable, Boolean isMobile) {
+    return reviewService.inquiryReviews(lectureId, pageable, isMobile);
   }
 
   public List<PreviewReviewResponse> inquiryPreviewReviews() {

--- a/src/main/java/com/cherrypick/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/cherrypick/backend/common/config/SecurityConfig.java
@@ -79,7 +79,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         "/swagger-ui/**",
         "/swagger-resources/**",
         "/v2/api-docs",
-        "/webjars/**"
+        "/webjars/**",
+        "/lectures/*",
+        "/reviews"
       ).permitAll()
       .antMatchers(
         "/oauth2/**"

--- a/src/main/java/com/cherrypick/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/cherrypick/backend/common/config/SecurityConfig.java
@@ -80,8 +80,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         "/swagger-resources/**",
         "/v2/api-docs",
         "/webjars/**",
-        "/lectures/*",
-        "/reviews"
+        "/user/v1/reviews"
       ).permitAll()
       .antMatchers(
         "/oauth2/**"

--- a/src/main/java/com/cherrypick/backend/common/jwt/JwtFilter.java
+++ b/src/main/java/com/cherrypick/backend/common/jwt/JwtFilter.java
@@ -25,8 +25,8 @@ public class JwtFilter extends GenericFilterBean {
     FilterChain filterChain)
     throws IOException, ServletException {
     HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-    String jwt = resolveToken(httpServletRequest);
     String requestURI = httpServletRequest.getRequestURI();
+    String jwt = resolveToken(httpServletRequest);
 
     if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) { // 토큰의 유효성이 검증됐을 경우,
       Authentication authentication = tokenProvider.getAuthentication(jwt);
@@ -46,6 +46,6 @@ public class JwtFilter extends GenericFilterBean {
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
       return bearerToken.substring(7);
     }
-    return null;
+    return tokenProvider.createNonMemberToken();
   }
 }

--- a/src/main/java/com/cherrypick/backend/common/jwt/TokenProvider.java
+++ b/src/main/java/com/cherrypick/backend/common/jwt/TokenProvider.java
@@ -13,6 +13,7 @@ import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
@@ -29,6 +30,7 @@ import org.springframework.stereotype.Component;
 public class TokenProvider implements InitializingBean {
 
   private static final String AUTHORITIES_KEY = "cp";
+  private static final String NON_MEMBER = "NonMember";
   private final String secret;
   private final long tokenValidityInMilliseconds;
   private final long accessTokenValidityInMilliseconds;
@@ -71,6 +73,19 @@ public class TokenProvider implements InitializingBean {
     return Jwts.builder()
       .setSubject(authentication.getName())
       .claim(AUTHORITIES_KEY, authorities)
+      .signWith(key, SignatureAlgorithm.HS512)
+      .setExpiration(validity)
+      .compact();
+  }
+
+  public String createNonMemberToken() {
+    UUID uuid = UUID.randomUUID();
+    long now = (new Date()).getTime();
+    Date validity = new Date(now + this.tokenValidityInMilliseconds);
+
+    return Jwts.builder()
+      .setSubject(NON_MEMBER + uuid)
+      .claim(AUTHORITIES_KEY, new SimpleGrantedAuthority(NON_MEMBER))
       .signWith(key, SignatureAlgorithm.HS512)
       .setExpiration(validity)
       .compact();

--- a/src/main/java/com/cherrypick/backend/domain/review/ReviewReader.java
+++ b/src/main/java/com/cherrypick/backend/domain/review/ReviewReader.java
@@ -3,7 +3,6 @@ package com.cherrypick.backend.domain.review;
 import com.cherrypick.backend.domain.review.ReviewInfo.ReviewDetail;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -11,11 +10,9 @@ public interface ReviewReader {
 
   List<ReviewDetail> findAllByLectureId(Long lectureId);
 
-  Page<ReviewDetail> findAllReviewPageableByLectureId(Long lectureId,
-    Pageable pageable);
+  Slice<ReviewDetail> findAllReviewPageableByLectureId(Long lectureId,
+    Pageable pageable, Boolean isMobile);
 
-  Slice<ReviewDetail> findAllReviewSliceByLectureId(Long lectureId,
-    Pageable pageable);
 
   Optional<Long> findMaxId();
 

--- a/src/main/java/com/cherrypick/backend/domain/review/ReviewService.java
+++ b/src/main/java/com/cherrypick/backend/domain/review/ReviewService.java
@@ -3,7 +3,6 @@ package com.cherrypick.backend.domain.review;
 import com.cherrypick.backend.domain.review.ReviewInfo.ReviewDetail;
 import com.cherrypick.backend.domain.review.ReviewInfo.ReviewStatistics;
 import java.util.List;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -13,9 +12,7 @@ public interface ReviewService {
 
   void createReview(ReviewCommand.RegisterRequest command);
 
-  Page<ReviewDetail> inquiryReviews(Long lectureId, Pageable pageable);
-
-  Slice<ReviewDetail> inquiryReviewsForMobile(Long lectureId, Pageable pageable);
+  Slice<ReviewDetail> inquiryReviews(Long lectureId, Pageable pageable, Boolean isMobile);
 
   List<ReviewDetail> inquiryPreviewReviews();
 }

--- a/src/main/java/com/cherrypick/backend/domain/review/ReviewServiceImpl.java
+++ b/src/main/java/com/cherrypick/backend/domain/review/ReviewServiceImpl.java
@@ -13,7 +13,6 @@ import com.cherrypick.backend.domain.user.UserReader;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -58,15 +57,9 @@ public class ReviewServiceImpl implements ReviewService {
   }
 
   @Override
-  public Page<ReviewDetail> inquiryReviews(Long lectureId, Pageable pageable) {
+  public Slice<ReviewDetail> inquiryReviews(Long lectureId, Pageable pageable, Boolean isMobile) {
     return reviewReader.findAllReviewPageableByLectureId(lectureId,
-      pageable);
-  }
-
-  @Override
-  public Slice<ReviewDetail> inquiryReviewsForMobile(Long lectureId, Pageable pageable) {
-    return reviewReader.findAllReviewSliceByLectureId(lectureId,
-      pageable);
+      pageable, isMobile);
   }
 
   @Override

--- a/src/main/java/com/cherrypick/backend/infrastructure/review/ReviewReaderImpl.java
+++ b/src/main/java/com/cherrypick/backend/infrastructure/review/ReviewReaderImpl.java
@@ -5,7 +5,6 @@ import com.cherrypick.backend.domain.review.ReviewReader;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
@@ -22,15 +21,9 @@ public class ReviewReaderImpl implements ReviewReader {
   }
 
   @Override
-  public Page<ReviewDetail> findAllReviewPageableByLectureId(Long lectureId,
-    Pageable pageable) {
-    return reviewRepositoryQueryDsl.findAllReviewPageableByLectureId(lectureId, pageable);
-  }
-
-  @Override
-  public Slice<ReviewDetail> findAllReviewSliceByLectureId(Long lectureId,
-    Pageable pageable) {
-    return reviewRepositoryQueryDsl.findAllReviewSliceByLectureId(lectureId, pageable);
+  public Slice<ReviewDetail> findAllReviewPageableByLectureId(Long lectureId,
+    Pageable pageable, Boolean isMobile) {
+    return reviewRepositoryQueryDsl.findAllReviewPageableByLectureId(lectureId, pageable, isMobile);
   }
 
   @Override

--- a/src/main/java/com/cherrypick/backend/presentation/lecture/LectureController.java
+++ b/src/main/java/com/cherrypick/backend/presentation/lecture/LectureController.java
@@ -23,7 +23,6 @@ public class LectureController {
 
   private final LectureFacade lectureFacade;
 
-  @PreAuthorize("hasAnyRole('ROLE_USER') or hasAnyRole('ROLE_ADMIN') or hasAnyRole('ROLE_MEMBERSHIP')")
   @GetMapping("/lectures")
   public ResponseEntity<CommonResponse> inquiryLectures(
     Principal principal,
@@ -38,7 +37,6 @@ public class LectureController {
     return ResponseEntity.ok(CommonResponse.success(response));
   }
 
-  @PreAuthorize("hasAnyRole('ROLE_USER') or hasAnyRole('ROLE_ADMIN') or hasAnyRole('ROLE_MEMBERSHIP')")
   @GetMapping("/lectures/{lectureId}")
   public ResponseEntity<CommonResponse> inquiryLectureDetail(
     Principal principal,

--- a/src/main/java/com/cherrypick/backend/presentation/lecture/LectureDto.java
+++ b/src/main/java/com/cherrypick/backend/presentation/lecture/LectureDto.java
@@ -9,6 +9,7 @@ import com.cherrypick.backend.domain.review.ReviewInfo.RecommendationStatics;
 import com.cherrypick.backend.domain.review.ReviewInfo.ReviewStatistics;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -25,10 +26,11 @@ public class LectureDto {
 
     public LectureCommand.ConditionRequest toCommand(String loginId,
       LectureDto.ConditionRequest request) {
+
       return new LectureCommand.ConditionRequest(
         request.getSearchName(),
         request.getCategoryId(),
-        request.getDepth(),
+        Optional.ofNullable(depth).orElse(3),
         loginId
       );
     }

--- a/src/main/java/com/cherrypick/backend/presentation/review/ReviewController.java
+++ b/src/main/java/com/cherrypick/backend/presentation/review/ReviewController.java
@@ -43,11 +43,7 @@ public class ReviewController {
     Pageable pageable,
     @RequestParam(value = "isMobile", required = false, defaultValue = "false") Boolean isMobile
   ) {
-    if (isMobile) {
-      var response = reviewFacade.inquiryReviewsForMobile(lectureId, pageable);
-      return ResponseEntity.ok(CommonResponse.success(response));
-    }
-    var response = reviewFacade.inquiryReviews(lectureId, pageable);
+    var response = reviewFacade.inquiryReviews(lectureId, pageable, isMobile);
     return ResponseEntity.ok(CommonResponse.success(response));
   }
 


### PR DESCRIPTION
## 작업내역
- [x] endpoint별 접근권한 재수정
- [x] 강의 검색 조회시 depth를 넣지 않으면 ne 발생 수정
- [x] lecture와 동일한 포맷으로 review수정
- [x] 비회원 전용 jwt 발급 로직 추가

## 추가설명
강의 검색은 회원이 아니라도 접근할 수 있어 permitAll로 해야하지만 강의 검색시 북마크 여부를 확인하기 위해 jwt안에 있는 id가 필요하여  permitAll로 설정할 수 없어 대안으로 비회원 jwt로직을 추가했습니다. 
더 좋은 방법이 있으면 말해주세요!